### PR TITLE
Fix: Minor space issue between the end of a sentence and the start of a new one

### DIFF
--- a/src/content/the-last-economy/chapter-18.mdx
+++ b/src/content/the-last-economy/chapter-18.mdx
@@ -43,15 +43,15 @@ Using a single, scarcity based currency for both is a design flaw of civilizatio
 
 The solution is to design the right tool for each job. Two worlds need two currencies. This is not a vague proposal; it is an engineering blueprint.
 
-**1\. Foundation Coins (FC): Money as Crystallized Intelligence**  
+**1\. Foundation Coins (FC): Money as Crystallized Intelligence**
 This is the currency for the Atomic Economy, designed as a stable store of value and an anchor to physical reality.
 
 - **Its Purpose:** To properly price and steward our scarce Material Capital (M).
 - **Its Creation:** We replace money born from debt or wasteful work with Money Born from Benefit. A new Foundation Coin is minted _only_ when the network can cryptographically verify that a specific amount of useful computation has been performed for the open intelligence commons. This includes curating a new dataset, training a foundational AI model, or performing a scientific simulation that solves a public problem.
-- **Its Physics:** The creation of money is now directly tethered to the efficient conversion of energy into intelligence.A Foundation Coin is a tokenized receipt for a unit of newly created, verifiably beneficial, low entropy order. It is, quite literally, crystallized intelligence.
+- **Its Physics:** The creation of money is now directly tethered to the efficient conversion of energy into intelligence. A Foundation Coin is a tokenized receipt for a unit of newly created, verifiably beneficial, low entropy order. It is, quite literally, crystallized intelligence.
 - **Its Scarcity:** Its supply is capped, ensuring it remains scarce and resistant to inflation.
 
-**2\. Culture Credits (CC): The Currency of Flow**  
+**2\. Culture Credits (CC): The Currency of Flow**
 This is the currency for the Bit Economy, designed as an abundant medium of exchange to foster creativity and collaboration.
 
 - **Its Purpose:** To maximize the creation and circulation of Intelligence (I) and Network (N) Capital.
@@ -62,8 +62,8 @@ This is the currency for the Bit Economy, designed as an abundant medium of exch
 
 ## From a Physics of Power to a Physics of Intelligence
 
-This dual system represents a fundamental shift in the physics of money.  
-The old monetary systems are based on a physics of power. Fiat currency is valuable because the state has the power to compel its use. Bitcoin is valuable because its network has the power to consume immense energy.  
+This dual system represents a fundamental shift in the physics of money.
+The old monetary systems are based on a physics of power. Fiat currency is valuable because the state has the power to compel its use. Bitcoin is valuable because its network has the power to consume immense energy.
 The new system is based on a physics of intelligence. Foundation Coins are valuable because they are the direct, auditable result of the efficient conversion of energy into useful order. Its backing is not the power of a state or the hash rate of a network, but the demonstrated intelligence of its participants.
 
 This is not just a monetary system. It is a generative, anti-entropic engine. It is an economy designed to fund its own evolution toward greater intelligence, resilience, and shared prosperity.

--- a/src/content/the-last-economy/chapter-2.mdx
+++ b/src/content/the-last-economy/chapter-2.mdx
@@ -18,7 +18,7 @@ Five days later, on Black Tuesday, the market lost twelve percent of its value i
 
 The history books miss the most important lesson of that moment. Everyone saw the crash coming. Not the specific date, but the _wrongness_. The fevered speculation, the shoeshine boys giving stock tips, the pyramids of paper wealth built on foundations of vapor. These harbingers are signals, signals that precede storms. They saw the signs, the harbingers of the storm, but they lacked the language to name them.
 
-We have that language now. It comes not from economics, but from physics, from the study of complex systems approaching a critical transition.If you have been feeling that something is fundamentally wrong with the world but could not articulate what, now you can. It is not anxiety. It is pattern recognition. Your brain is processing these harbingers even if you lack the vocabulary. That feeling of deep, systemic _wrongness_? That is your limbic system screaming that the water is about to boil.
+We have that language now. It comes not from economics, but from physics, from the study of complex systems approaching a critical transition. If you have been feeling that something is fundamentally wrong with the world but could not articulate what, now you can. It is not anxiety. It is pattern recognition. Your brain is processing these harbingers even if you lack the vocabulary. That feeling of deep, systemic _wrongness_? That is your limbic system screaming that the water is about to boil.
 
 An economy, like water about to boil, a forest about to catch fire, or tectonic plates about to slip, displays specific, measurable behaviors as it approaches a phase transition. These are not warnings. They are physical laws in motion.
 


### PR DESCRIPTION
This PR fixes multiple minor spacing and formatting issues found across chapters:

## Chapter 2
- Add missing space after period in 'transition.If you have been feeling' → 'transition. If you have been feeling'

## Chapter 18  
- Add missing space after period in 'intelligence.A Foundation Coin' → 'intelligence. A Foundation Coin'
- Remove trailing spaces from section headers for consistency
- Clean up formatting inconsistencies throughout the chapter

These changes improve readability and maintain consistent formatting standards across the documentation.