### PR TITLE
Add concrete examples of GDP's perverse incentives in chapter 3

### DIFF
--- a/src/content/the-last-economy/chapter-3.mdx
+++ b/src/content/the-last-economy/chapter-3.mdx
@@ -68,7 +68,9 @@ _What does equilibrium mean in a market designed for exponential acceleration?_
 
 **The Reality Check:** Wikipedia provides twenty billion pages of free knowledge monthly. Its contribution to human flourishing is incalculable. Its contribution to GDP, however, is negative because it destroyed the encyclopedia industry, a market where a single set of Britannica encyclopedias once cost consumers $1,400.
 
-This reveals the central perversity of our economic dashboard: it registers the creation of immense public value as a loss, while consistently counting the human tragedies and social costs detailed in the preceding exhibits as positive growth. We measure destruction as production and wonder why society feels like it is falling apart while the numbers go up.
+Meanwhile, GDP celebrates actual human tragedies as economic growth. A divorce boosts GDP through lawyer fees, court costs, and duplicate housing. A hurricane is an economic bonanza: insurance payouts, reconstruction spending, and replacement purchases all count as positive growth. A mass shooting triggers a surge in security spending, therapy sessions, and funeral services that our economic dashboard registers as prosperity. The opioid crisis has been a GDP goldmine: pharmaceutical sales, addiction treatment centers, and rehabilitation facilities all contribute to the "growing economy."
+
+This reveals the central perversity of our economic dashboard: it registers the creation of immense public value as a loss, while consistently counting human tragedies and social costs as positive growth. We measure destruction as production and wonder why society feels like it is falling apart while the numbers go up.
 
 _If the best things in life are free, why is our economy designed to measure only the things that cost money?_
 


### PR DESCRIPTION
This PR strengthens the critique of GDP by adding visceral, concrete examples of how our economic dashboard perversely measures human suffering as prosperity.

## Content Enhancement

**Added concrete examples of GDP perversity:**
- **Divorces** → Lawyer fees, court costs, duplicate housing expenses
- **Hurricanes** → Insurance payouts, reconstruction spending, replacement purchases  
- **Mass shootings** → Security spending, therapy sessions, funeral services
- **Opioid crisis** → Pharmaceutical sales, treatment centers, rehabilitation facilities

## Why This Improves the Chapter

1. **Emotional Impact** - Transforms abstract economic criticism into visceral understanding
2. **Concrete Evidence** - Provides specific, relatable examples readers can immediately grasp
3. **Stronger Argument** - Shows this isn't just about Wikipedia vs encyclopedias, but a systemic flaw
4. **Better Flow** - Builds momentum before the concluding critique about measuring destruction as production
5. **Memorable** - Readers will remember these examples when they see GDP growth celebrated in news

## Before vs After Structure

**Before:** Wikipedia example → Abstract critique about measuring destruction as production

**After:** Wikipedia example → Multiple visceral examples of tragedies counted as growth → Strengthened critique

This change makes the argument more persuasive and emotionally resonant while maintaining the logical structure.