### PR TITLE
Clarify pronoun reference in rational actor question

### DIFF
--- a/src/content/the-last-economy/chapter-3.mdx
+++ b/src/content/the-last-economy/chapter-3.mdx
@@ -80,7 +80,7 @@ _If the best things in life are free, why is our economy designed to measure onl
 
 **The Reality Check:** We are not rational actors in an impartial environment. We are biological creatures with predictable cognitive biases, and we now live in an environment that has been perfectly engineered to exploit those biases for profit. Every tech platform is an addiction machine, using variable ratio reinforcement and social validation loops to hijack our dopamine systems. We are not optimizing the system; the system is optimizing us to be perfect consumers.
 
-_Who is the rational actor in a battle between a human mind and an algorithm that knows it better than it knows itself?_
+_Who is the rational actor in a battle between a human mind and an algorithm that knows the human better than the human knows itself?_
 
 **Why the Lie is Fatal:** In the age of AI, this asymmetry becomes absolute. AI can model our individual psychology, predict our desires, and generate personalized content to manipulate our behavior with superhuman effectiveness. The "rational actor" is not just a fiction; it is a defenseless target. Any economic or political theory based on consumer sovereignty or the "wisdom of the crowd" is now obsolete and dangerous.
 


### PR DESCRIPTION
This PR fixes an ambiguous pronoun reference that could confuse readers in a key rhetorical question about AI vs human cognition.

## The Issue

**Before:**
> Who is the rational actor in a battle between a human mind and an algorithm that knows it better than it knows itself?

The pronoun "it" is ambiguous - readers might wonder if it refers to:
- The human mind
- The algorithm  

## The Fix

**After:**
> Who is the rational actor in a battle between a human mind and an algorithm that knows the human better than the human knows itself?

## Why This Matters

1. **Eliminates Confusion** - Removes cognitive load from readers trying to parse pronoun reference
2. **Clearer Message** - Makes the power dynamic explicitly about algorithm > human self-knowledge  
3. **Better Impact** - The rhetorical punch lands more directly without ambiguity
4. **Professional Polish** - Shows attention to clarity in critical passages

## Context

This question appears in the "Rational Actors" section where the argument is that humans are predictably irrational and algorithms can exploit this. The clarified version makes the terrifying implication more explicit: AI systems now know us better than we know ourselves.

Small change, big improvement in readability and impact.