### PR TITLE
Fix variables in Intelligence Lagrangian in Appendix A

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -87,7 +87,7 @@ export default async function RootLayout({ children }) {
             // banner={<Banner storageKey="Nextra 2">Nextra 2 Alpha</Banner>}
             navbar={navbar}
             editLink="Edit this page on GitHub"
-            docsRepositoryBase="https://github.com/Intelligent-Internet/Symbioism-Nextra"
+            docsRepositoryBase="https://github.com/Intelligent-Internet/Symbioism-Nextra/tree/main"
             sidebar={{ defaultMenuCollapseLevel: 1 }}
             pageMap={pageMap}
             nextThemes={{ forcedTheme: 'dark' }}

--- a/src/content/the-last-economy/appendix-a.mdx
+++ b/src/content/the-last-economy/appendix-a.mdx
@@ -26,7 +26,7 @@ The instantaneous value of the Intelligence Action is the **Lagrangian**. This t
 
 - **Definition 1: The Intelligence Lagrangian.** Intelligence Langrian, L, is the sum of three minimal, irreducible computational costs:
 
-  L = H(q, t) + C(q) + K(_r_)
+  L = A(q, t) + C(q) + E(_r_)
 
 **Let us examine each component:**
 


### PR DESCRIPTION
Updated the definition of the Intelligence Lagrangian to replace 'H' with 'A' and 'K' with 'E' in the equation, to be in line with the rest of explanation.